### PR TITLE
Fix comparison with NAN in heatmap.py

### DIFF
--- a/eyeGestures/screenTracker/heatmap.py
+++ b/eyeGestures/screenTracker/heatmap.py
@@ -36,7 +36,7 @@ class Heatmap():
         if len(retArray[0]) > 0:
             ret = retArray[0][- int(last)] * self.step
 
-            if not ret == np.NAN:
+            if not ret == np.nan:
                 ret = int(ret)
 
         return ret


### PR DESCRIPTION
#### Background
This PR resolves #28, where the use of `np.NAN` in `heatmap.py` causes an `AttributeError` in NumPy version 2.1. To resolve this, all instances of `np.NAN` are replaced with `np.nan`, ensuring compatibility with both current and future versions of NumPy, as recommended by the [NumPy stable documentation](https://numpy.org/doc/stable/reference/constants.html#numpy.nan) and the [NumPy 1.26 documentation](https://numpy.org/doc/1.26/reference/constants.html#numpy.NAN).

#### Current Behavior
Using `np.NAN` results in `AttributeError: module 'numpy' has no attribute 'NAN'`, causing errors in NumPy 2.1.

#### Expected Behavior
The code will now use `np.nan` for NaN handling, eliminating the `AttributeError` and ensuring compatibility across NumPy versions.